### PR TITLE
fix casting issue for statistics package, fix matplotlib keymap conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+data/*
+weights/*

--- a/predictor.py
+++ b/predictor.py
@@ -58,6 +58,11 @@ def closetn(node, nodes):
 
 sys.path.append("..")
 
+try:
+    matplotlib.use('Qt5Agg')
+except:
+    matplotlib.use('TkAgg')
+
 sam_checkpoint = 'sam_vit_h_4b8939.pth'
 model_type = "vit_h"
 
@@ -118,7 +123,6 @@ if first == 'n':
     c = 0
     tim = 0
     t = time.time()
-
 else:
     from openpyxl import load_workbook
 
@@ -170,11 +174,6 @@ while c < 150 and not f:
     label = label == 1
 
     # matplotlib.use('TkAgg')
-    try:
-
-        matplotlib.use('Qt5Agg')
-    except:
-        matplotlib.use('TkAgg')
 
     while inc != "y":
         s = 0  # this is for the score

--- a/predictor.py
+++ b/predictor.py
@@ -334,8 +334,11 @@ while c < 150 and not f:
                     rp.append(np.multiply(red, 1))
                     ng.append(len(greenx))
                     nr.append(len(redx))
-                    stdx.append(statistics.pstdev(np.concatenate((greenx, redx))))
-                    stdy.append(statistics.pstdev(np.concatenate((greeny, redy))))
+                    grx = np.concatenate([greenx, redx])
+                    gry = np.concatenate([greeny, redy])
+
+                    stdx.append(statistics.pstdev(grx.astype(int).tolist()))
+                    stdy.append(statistics.pstdev(gry.astype(int).tolist()))
                     print("up count", count)
                     if maxx >= s:
                         print("inside",count)

--- a/predictor.py
+++ b/predictor.py
@@ -24,6 +24,8 @@ from PIL import Image
 from segment_anything import sam_model_registry, SamPredictor
 import matplotlib
 
+plt.rcParams['keymap.grid'].remove('g')
+plt.rcParams['keymap.home'].remove('r')
 
 # %%
 # names=os.listdir('C:/Users/Mohammed/Downloads/saltdome')


### PR DESCRIPTION
Fixing two things here:

- The `statistics` package was throwing an error because `np.int32` does not have `bit_length` property. The fix cast the elements back to standard `int` type before calling the `pstdev` function.
- `matplotlib` has two conflicting keymaps with `g` and `r` which is distracting and disrupts zooming. The fix disables `g` from toggling the grid and disables `r` from homing the figure (`h` will still work).